### PR TITLE
fix: required shema typo

### DIFF
--- a/src/routes/v1/posts/schema.ts
+++ b/src/routes/v1/posts/schema.ts
@@ -32,7 +32,7 @@ export type PostNotFound = FromSchema<typeof postNotFoundSchema>
 // Params Schema
 const paramsSchema = {
   type: 'object',
-  require: ['postid'],
+  required: ['postid'],
   properties: {
     postid: { type: 'number' }
   },


### PR DESCRIPTION
Failed building the validation schema for GET: /v1/posts/:postid, due to error strict mode: unknown keyword: \"require\"