### PR TITLE
fix(plugins\sensible.ts): dropped custom errorHandler option 

### DIFF
--- a/src/plugins/sensible.ts
+++ b/src/plugins/sensible.ts
@@ -7,7 +7,5 @@ import sensible, { SensibleOptions } from '@fastify/sensible'
  * @see https://github.com/fastify/fastify-sensible
  */
 export default fp<SensibleOptions>(async (fastify, opts) => {
-  fastify.register(sensible, {
-    errorHandler: false
-  })
+  fastify.register(sensible)
 })


### PR DESCRIPTION
Dropped custom errorHandler option in @fastify/sensible registration plugin.

Compatibilty with Fastify v4 https://github.com/fastify/fastify-sensible/pull/109